### PR TITLE
Replace racy half-open increment-if-zero with a compare-and-swap

### DIFF
--- a/circuitbreaker.go
+++ b/circuitbreaker.go
@@ -131,8 +131,7 @@ func (cb *CircuitBreaker) state() state {
 	if cb.failures >= cb.Threshold {
 		since := time.Since(cb.lastFailure())
 		if since > cb.ResetTimeout {
-			if cb.halfOpens == 0 {
-				atomic.AddInt64(&cb.halfOpens, 1)
+			if atomic.CompareAndSwapInt64(&cb.halfOpens, 0, 1) {
 				return halfopen
 			}
 			return open


### PR DESCRIPTION
The current code is racy:

```
if cb.halfOpens == 0 {
  atomic.AddInt64(&cb.halfOpens, 1)
  return halfopen
}
```

This commit replaces the increment-if-zero with a compare-and-swap-if-zero, ensuring that only one thread will return `halfopen`, which seems to be the intent of the current code.
