### PR TITLE
Use atomic.LoadPointer() to read pointers stored atomically

### DIFF
--- a/circuitbreaker.go
+++ b/circuitbreaker.go
@@ -143,5 +143,6 @@ func (cb *CircuitBreaker) state() state {
 }
 
 func (cb *CircuitBreaker) lastFailure() time.Time {
-	return *(*time.Time)(cb._lastFailure)
+	ptr := atomic.LoadPointer(&cb._lastFailure)
+	return *(*time.Time)(ptr)
 }


### PR DESCRIPTION
Just like there's nothing to guarantee that simply storing a pointer is atomic, there's nothing to guarantee that simply loading a pointer is either. This commit uses `atomic.LoadPointer()` to load the pointer stored with `atomic.StorePointer()`.
