### PR TITLE
Resetting ThresholdBreaker

### DIFF
--- a/circuitbreaker.go
+++ b/circuitbreaker.go
@@ -176,7 +176,7 @@ func (cb *ThresholdBreaker) Reset() {
 
 // Failures returns the number of failures for this circuit breaker.
 func (cb *ThresholdBreaker) Failures() int64 {
-	return atomic.LoadInt64(&cb.failures, 0)
+	return atomic.LoadInt64(&cb.failures)
 }
 
 // ResetFailures resets the failure count for this circuit breaker.  The state


### PR DESCRIPTION
Not sure why we need to return 0.  This matches the `*CircuitBreaker` `Reset()` signature.

This also adds a way to get and reset the failure count for a `*ThresholdBreaker`.  I think we can solve #6 by a `time.Ticker` that resets the failure count every minute or whatever.
