### PR TITLE
Fix bug in statsd bucket name documentation

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -137,7 +137,7 @@ func ExamplePanel_stats() {
 	breaker := NewThresholdBreaker(10)
 	panel := NewPanel()
 	panel.Statter = s
-	panel.StatsPrefixf = "sys.production"
+	panel.StatsPrefixf = "sys.production.%s"
 	panel.Add("x", breaker)
 
 	breaker.Trip()  // sys.production.circuit.x.tripped


### PR DESCRIPTION
 needs to be a format string.