### PR TITLE
respect backoff.Stop to stop retrying forever

### DIFF
--- a/circuitbreaker.go
+++ b/circuitbreaker.go
@@ -339,7 +339,7 @@ func (cb *Breaker) state() state {
 		}
 
 		since := cb.Clock.Now().Sub(cb.lastFailure())
-		if since > cb.nextBackOff {
+		if cb.nextBackOff != backoff.Stop && since > cb.nextBackOff {
 			if atomic.CompareAndSwapInt64(&cb.halfOpens, 0, 1) {
 				cb.nextBackOff = cb.BackOff.NextBackOff()
 				return halfopen


### PR DESCRIPTION
`backoff.NextBackOff()` might return `backoff.Stop` that we need to check against to stop retrying, otherwise every `cb.Call()` results in a retry.

quick ref: https://github.com/cenkalti/backoff/blob/4dc77674aceaabba2c7e3da25d4c823edfb73f99/backoff.go#L16