### PR TITLE
Set Backoff.MaxElapsedTime 0 as a default

### DIFF
--- a/circuitbreaker.go
+++ b/circuitbreaker.go
@@ -65,7 +65,10 @@ const (
 	closed   state = iota
 )
 
-var defaultInitialBackOffInterval = 500 * time.Millisecond
+var (
+	defaultInitialBackOffInterval = 500 * time.Millisecond
+	defaultBackoffMaxElapsedTime  = 0 * time.Second
+)
 
 // Error codes returned by Call
 var (
@@ -125,6 +128,7 @@ func NewBreakerWithOptions(options *Options) *Breaker {
 	if options.BackOff == nil {
 		b := backoff.NewExponentialBackOff()
 		b.InitialInterval = defaultInitialBackOffInterval
+		b.MaxElapsedTime = defaultBackoffMaxElapsedTime
 		b.Clock = options.Clock
 		b.Reset()
 		options.BackOff = b


### PR DESCRIPTION
Hi, guys.

We are using rubyst/circuitbreaker in my app.
We've found that our network client that wrapping rubyst/circuitbreaker doesn't start to request to the server that recovered from a long failure (>=15min).

After some investigation, We found that `Breaker` stop retrying.
That's because ``backoff.Backoff`` started returning ``backoff.Stop`` if it would kept open longer than 15 minutes as a default and #30 respect the response.

But I think many users expect CircuitBreaker implementations to retry forever and close itself it it could.
So, in order to avoid error-prone, I'd like to change default behavior of `Breaker` to retry forever when it is opened.

Could you please consider my proposal?