### PR TITLE
Fix goroutine leak when using timeouts.

### DIFF
--- a/circuitbreaker.go
+++ b/circuitbreaker.go
@@ -308,7 +308,7 @@ func (cb *Breaker) Call(circuit func() error, timeout time.Duration) error {
 	if timeout == 0 {
 		err = circuit()
 	} else {
-		c := make(chan error)
+		c := make(chan error, 1)
 		go func() {
 			c <- circuit()
 			close(c)


### PR DESCRIPTION
If a timeout occurs when executing a call, there is no reader on the result channel and the goroutine blocks forever.  This adds a buffer to the channel so the goroutine can exit and the result can be later garbage collected.