### PR TITLE
Fix window buckets that should be empty

### DIFF
--- a/window_test.go
+++ b/window_test.go
@@ -51,4 +51,18 @@ func TestWindowSlides(t *testing.T) {
 	if counts != 2 {
 		t.Fatalf("expected 2 buckets to have failures, got %d", counts)
 	}
+
+	time.Sleep(15 * time.Millisecond)
+	w.Success()
+	counts = 0
+	w.buckets.Do(func(x interface{}) {
+		b := x.(*bucket)
+		if b.failure > 0 {
+			counts++
+		}
+	})
+
+	if counts != 0 {
+		t.Fatalf("expected 0 buckets to have failures, got %d", counts)
+	}
 }


### PR DESCRIPTION
If you have a window of 10 seconds with 10 buckets and if you have one event per second, you will have a total of 10 events.  If you wait 10 seconds and send another event, you should have 1 total events for the window.  Currently, you will get 10 since only one bucket is reset no matter what the elapsed time has been between now and the last time an event was recorded.  This fixes this and resets the buckets between now and the last time an event was recorded.