### PR TITLE
Fix issue #43 [Value alignment issue on 32-bit systems (ARM)]

### DIFF
--- a/circuitbreaker.go
+++ b/circuitbreaker.go
@@ -104,10 +104,11 @@ type Breaker struct {
 	// Clock is used for controlling time in tests.
 	Clock clock.Clock
 
+	_              [4]byte // pad to fix golang issue #599
 	consecFailures int64
-	counts         *window
 	lastFailure    int64 // stored as nanoseconds since the Unix epoch
 	halfOpens      int64
+	counts         *window
 	nextBackOff    time.Duration
 	tripped        int32
 	broken         int32


### PR DESCRIPTION
Reordered Breaker struct and added padding to ensure that the 64-bit values have 8-byte alignment on 32-bit systems. This is required by the atomic library for values larger than 4 bytes on 32-bit systems and will cause a panic if that alignment is incorrect.