### PR TITLE
BreakerEvent now implements Stringer interface

### DIFF
--- a/circuitbreaker.go
+++ b/circuitbreaker.go
@@ -58,6 +58,22 @@ const (
 	BreakerReady BreakerEvent = iota
 )
 
+// String returns BreakerEvent description
+func (e BreakerEvent) String() string {
+	switch e {
+	case BreakerTripped:
+		return "breaker is open"
+	case BreakerReset:
+		return "breaker is closed"
+	case BreakerFail:
+		return "Fail() was called"
+	case BreakerReady:
+		return "breaker is ready to retry"
+	default:
+		return "unknown event"
+	}
+}
+
 // ListenerEvent includes a reference to the circuit breaker and the event.
 type ListenerEvent struct {
 	CB    *Breaker

--- a/circuitbreaker_test.go
+++ b/circuitbreaker_test.go
@@ -474,3 +474,45 @@ func TestPartialSecondBackoff(t *testing.T) {
 		t.Fatalf("expected breaker to be ready after more than nextBackoff time had passed")
 	}
 }
+
+// TestBreakerEvent_String ensures that BreakerEvent implements Stringer interfaces properly
+func TestBreakerEvent_String(t *testing.T) {
+	tests := []struct {
+		name string
+		e    BreakerEvent
+		want string
+	}{
+		{
+			name: "BreakerTripped",
+			e:    BreakerTripped,
+			want: "breaker is open",
+		},
+		{
+			name: "BreakerReset",
+			e:    BreakerReset,
+			want: "breaker is closed",
+		},
+		{
+			name: "BreakerFail",
+			e:    BreakerFail,
+			want: "Fail() was called",
+		},
+		{
+			name: "BreakerReady",
+			e:    BreakerReady,
+			want: "breaker is ready to retry",
+		},
+		{
+			name: "UnknownBreakerEvent",
+			e:    BreakerEvent(9999),
+			want: "unknown event",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.e.String(); got != tt.want {
+				t.Errorf("BreakerEvent.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Hello

Thanks for the library.
I added implementation of `Stringer` interface for `BreakerEvent`

```
ch := builder.cb.Subscribe()
	go func() {
		for {
			e := <- ch
			fmt.Println(e) // prints nice message instead of a numeric value
		}
	}()
```