### PR TITLE
Use Request context for HTTPClient.Do

### DIFF
--- a/client.go
+++ b/client.go
@@ -94,7 +94,8 @@ func (c *HTTPClient) Do(req *http.Request) (*http.Response, error) {
 	var resp *http.Response
 	var err error
 	breaker := c.breakerLookup(req.URL.String())
-	err = breaker.Call(func() error {
+	ctx := req.Context()
+	err = breaker.CallContext(ctx, func() error {
 		resp, err = c.Client.Do(req)
 		return err
 	}, c.timeout)


### PR DESCRIPTION
If the context is cancelled on the request the breaker considers that an error.

Instead of creating a new context, we use the one provided on the `http.Request`, which returns `context.BackGround()` if none is set.