### PR TITLE
Use updated backoff import path

### DIFF
--- a/circuitbreaker.go
+++ b/circuitbreaker.go
@@ -37,7 +37,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cenk/backoff"
+	"github.com/cenkalti/backoff"
 	"github.com/facebookgo/clock"
 )
 

--- a/circuitbreaker_test.go
+++ b/circuitbreaker_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cenk/backoff"
+	"github.com/cenkalti/backoff"
 	"github.com/facebookgo/clock"
 )
 


### PR DESCRIPTION
github.com/cenk/backoff has been renamed back to
github.com/cenkalti/backoff.

Fixes #53.