### PR TITLE
Updated redirected dependency

### DIFF
--- a/circuitbreaker.go
+++ b/circuitbreaker.go
@@ -37,7 +37,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/cenk/backoff"
+	"github.com/cenkalti/backoff"
 	"github.com/facebookgo/clock"
 )
 

--- a/circuitbreaker_test.go
+++ b/circuitbreaker_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cenk/backoff"
+	"github.com/cenkalti/backoff"
 	"github.com/facebookgo/clock"
 )
 


### PR DESCRIPTION
The `github.com/cenk/backoff` repo has since been renamed to `github.com/cenkalti/backoff` which is causing issues for some of our internal tooling. This updates the dependecy to use the new repo.