### PR TITLE
Switches from facebookgo/clock to benbjohnson/clock

### DIFF
--- a/circuitbreaker.go
+++ b/circuitbreaker.go
@@ -38,7 +38,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
-	"github.com/facebookgo/clock"
+	"github.com/benbjohnson/clock"
 )
 
 // BreakerEvent indicates the type of event received over an event channel

--- a/circuitbreaker_test.go
+++ b/circuitbreaker_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff"
-	"github.com/facebookgo/clock"
+	"github.com/benbjohnson/clock"
 )
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/rubyist/circuitbreaker
+
+go 1.18
+
+require (
+	github.com/benbjohnson/clock v1.3.0
+	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea h1:sKwxy1H95npauwu8vtF95vG/syrL0p8fSZo/XlDg5gk=
+github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea/go.mod h1:1VcHEd3ro4QMoHfiNl/j7Jkln9+KQuorp0PItHMJYNg=

--- a/window.go
+++ b/window.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/facebookgo/clock"
+	"github.com/benbjohnson/clock"
 )
 
 var (

--- a/window_test.go
+++ b/window_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/facebookgo/clock"
+	"github.com/benbjohnson/clock"
 )
 
 func TestWindowCounts(t *testing.T) {


### PR DESCRIPTION
This PR switches from the facebookgo/clock dependency to benbjohnson/clock which is the more actively maintained drop-in replacement.

It also initializes the module using `go mody init`.