### PR TITLE
Simplifying timeout test case

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/rubyist/circuitbreaker
+
+go 1.21.0
+
+require (
+	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a
+	github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
+github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a h1:yDWHCSQ40h88yih2JAcL6Ls/kVkSE8GFACTGVnMPruw=
+github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40egUymuWXxAe151lTNnCv97MddSOVsjpPPkityA=
+github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea h1:sKwxy1H95npauwu8vtF95vG/syrL0p8fSZo/XlDg5gk=
+github.com/peterbourgon/g2s v0.0.0-20170223122336-d4e7ad98afea/go.mod h1:1VcHEd3ro4QMoHfiNl/j7Jkln9+KQuorp0PItHMJYNg=


### PR DESCRIPTION
-  Removed unnecessary concurrency pattern (wait channel)
- called variable was unused, I wrote a condition for that to be called once